### PR TITLE
fix/sources

### DIFF
--- a/quipus/data_sources/csv_source.py
+++ b/quipus/data_sources/csv_source.py
@@ -110,6 +110,9 @@ class CSVSource(FileSource):
             ValueError: If the `quote_char` is the same as the delimiter or not a single character.
             TypeError: If the `quote_char` is not a string.
         """
+        if value is None:
+            self._quote_char = value
+            return
         if not isinstance(value, str):
             raise TypeError("Quote character must be a string.")
         if len(value) != 1:
@@ -188,7 +191,7 @@ class CSVSource(FileSource):
             source=self.file_path,
             separator=self.delimiter,
             quote_char=self.quote_char,
-            encoding=self.encoding,
+            encoding=self.encoding.value,
             has_header=self.has_header,
             columns=self.columns,
             skip_rows=self.skip_rows,
@@ -208,7 +211,7 @@ class CSVSource(FileSource):
             n_rows=0,
             separator=self.delimiter,
             quote_char=self.quote_char,
-            encoding=self.encoding,
+            encoding=self.encoding.value,
             has_header=self.has_header,
         )
         return df.columns

--- a/quipus/data_sources/mongo_source.py
+++ b/quipus/data_sources/mongo_source.py
@@ -43,10 +43,17 @@ class MongoDBSource(DataBaseSource):
               Defaults to False.
 
         Raises:
+            ValueError: If neither db_config nor connection_string is provided.
             ValueError: If the collection_name is empty or invalid.
         """
+        if not db_config and not connection_string:
+            raise ValueError("Either db_config or connection_string must be provided.")
+
         if db_config and not connection_string:
             connection_string = self._build_connection_string(db_config, use_srv)
+
+        if not db_config and connection_string:
+            self.db_config.database = connection_string.split("/")[-1]
 
         super().__init__(connection_string=connection_string, db_config=db_config)
         self.collection_name = collection_name

--- a/quipus/data_sources/mysql_source.py
+++ b/quipus/data_sources/mysql_source.py
@@ -20,7 +20,6 @@ class MySQLSource(DataBaseSource):
     def __init__(
         self,
         query: str,
-        connection_string: Optional[str] = None,
         db_config: Optional[DBConfig] = None,
     ):
         """
@@ -28,20 +27,13 @@ class MySQLSource(DataBaseSource):
 
         Parameters:
             query (str): The SQL query to execute.
-            connection_string (Optional[str]): The connection string for the database.
-                Defaults to None, which constructs it from db_config if provided.
             db_config (Optional[DBConfig]): A DBConfig instance for constructing
                 the connection string. Defaults to None.
 
         Raises:
             ValueError: If the query is not a valid string.
         """
-        if db_config and not connection_string:
-            connection_string = (
-                f"mysql://{db_config.user}:{db_config.password}@"
-                f"{db_config.host}:{db_config.port}/{db_config.database}"
-            )
-        super().__init__(connection_string, db_config)
+        super().__init__(db_config)
         self._connection = None
         self.query = query
         self.connected = False


### PR DESCRIPTION
Enhancements to **CSVSource**:

* `quipus/data_sources/csv_source.py`:
  * Updated the `quote_char` method to handle `None` values gracefully.
  * Modified the `load_data` and `get_columns` methods to use `encoding.value` instead of `encoding`. 

Enhancements to **MongoSource**:

* `quipus/data_sources/mongo_source.py`:
  * Added a check in the `__init__` method to raise a `ValueError` if neither `db_config` nor `connection_string` is provided.

Enhancements to **MySQLSource**:

* `quipus/data_sources/mysql_source.py`: 
  * Removed the `connection_string` parameter from the `__init__` method and adjusted the initialization to use only `db_config`.