### PR TITLE
[FT] Add ReplacementsDict and ValidReplacementValue types for smtp replacements

### DIFF
--- a/quipus/__init__.py
+++ b/quipus/__init__.py
@@ -13,6 +13,8 @@ Classes and Components:
     EmailMessageBuilder: Helper class for constructing email messages.
     EmailSender: Class for sending emails via an SMTP server.
     EncodingType: Enum for file encoding types.
+    ReplacementsDict: TypedDict for template replacements validation.
+    ValidReplacementValue: Union type for valid replacement values.
     FileSource: Abstract base class for file-based data sources.
     MongoDBSource: Class for connecting to and loading data from MongoDB databases.
     MySQLSource: Class for connecting to and loading data from MySQL databases.
@@ -48,7 +50,7 @@ from .services import (
     SMTPConfig,
     TemplateManager,
 )
-from .utils import Connectable, DBConfig, EncodingType
+from .utils import Connectable, DBConfig, EncodingType, ReplacementsDict, ValidReplacementValue
 
 __all__ = [
     "AWSConfig",
@@ -61,6 +63,8 @@ __all__ = [
     "EmailMessageBuilder",
     "EmailSender",
     "EncodingType",
+    "ReplacementsDict",
+    "ValidReplacementValue",
     "FileSource",
     "MongoDBSource",
     "MySQLSource",

--- a/quipus/utils/__init__.py
+++ b/quipus/utils/__init__.py
@@ -7,15 +7,25 @@ It includes:
  processing.
 - Connectable: Abstract base class for defining connectable objects.
 - DBConfig: Class that handles database configuration settings.
+- ReplacementsDict: TypedDict for template replacements validation.
+- ValidReplacementValue: Union type for valid replacement values.
 
 Exports:
     EncodingType: Enum class for encoding types.
     Connectable: Abstract base class for connectable resources.
     DBConfig: Class for managing database configuration.
+    ReplacementsDict: TypedDict for template replacements validation.
+    ValidReplacementValue: Union type for valid replacement values.
 """
 
 from .connectable import Connectable
 from .dbconfig import DBConfig
-from .types import EncodingType
+from .types import EncodingType, ReplacementsDict, ValidReplacementValue
 
-__all__ = ["EncodingType", "Connectable", "DBConfig"]
+__all__ = [
+    "EncodingType",
+    "Connectable",
+    "DBConfig",
+    "ReplacementsDict",
+    "ValidReplacementValue",
+]

--- a/quipus/utils/types.py
+++ b/quipus/utils/types.py
@@ -1,4 +1,16 @@
 from enum import Enum
+from typing import TypedDict, Union
+
+ValidReplacementValue = Union[str, int, float, None]
+
+
+class ReplacementsDict(TypedDict, total=False):
+    """
+    TypedDict for template replacements validation.
+    Allows dynamic string keys with values of type str, int, float or None.
+    """
+
+    key: ValidReplacementValue
 
 
 class EncodingType(Enum):


### PR DESCRIPTION
### New Types for Template Replacements Validation:
* Added `ReplacementsDict` TypedDict and `ValidReplacementValue` Union type to `quipus/utils/types.py` for validating template replacements.

### Updates to `__init__.py`:
* Updated `quipus/__init__.py` to include the new `ReplacementsDict` and `ValidReplacementValue` in the imports and `__all__` list. 
* Updated `quipus/utils/__init__.py` to export the new types.

### Updates to `smtp_delivery.py`:
* Imported `ReplacementsDict` and `ValidReplacementValue` in `quipus/services/smtp_delivery.py`.
* Modified the `with_body_path` method to use `Optional[dict[str, ValidReplacementValue]]` for the `replacements` parameter and added type checks for replacement values.